### PR TITLE
fix: update posting_time format in TestITC04Export

### DIFF
--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -104,7 +104,7 @@ class TestITC04Export(IntegrationTestCase):
         cls.se.submit()
 
         cls.scr = make_subcontracting_receipt(sco.name)
-        cls.scr.update({"posting_date": "2025-01-10", "set_posting_time": 1})
+        cls.scr.update({"posting_date": "2025-01-10", "posting_time": "00:00:00"})
         cls.scr.save()
 
         cls.scr.append(

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -105,6 +105,7 @@ class TestITC04Export(IntegrationTestCase):
 
         cls.scr = make_subcontracting_receipt(sco.name)
         cls.scr.update({"posting_date": "2025-01-10", "posting_time": "00:00:00"})
+        cls.scr.set_posting_time = 1
         cls.scr.save()
 
         cls.scr.append(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated tests to set an explicit posting time ("00:00:00") and a separate flag for posting on subcontracting receipts, improving determinism and reducing time zone–related flakiness.
  * Enhances test clarity and reliability without altering application behavior or any user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->